### PR TITLE
Update peakTotalNonRevocableMemory to be nullable

### DIFF
--- a/alembic/versions/1670737c6856_make_peaktotalnonrevocablememorybytes_.py
+++ b/alembic/versions/1670737c6856_make_peaktotalnonrevocablememorybytes_.py
@@ -1,0 +1,41 @@
+"""make peakTotalNonRevocableMemoryBytes nullable
+
+Revision ID: 1670737c6856
+Revises: 5951554f7954
+Create Date: 2022-01-26 12:06:22.967428
+
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1670737c6856"
+down_revision = "5951554f7954"
+branch_labels = None
+depends_on = None
+
+
+COLUMN_NAME = "peakTotalNonRevocableMemoryBytes"
+
+
+def upgrade():
+    op.alter_column(
+        "query_metrics",
+        COLUMN_NAME,
+        schema="raw_metrics",
+        existing_type=sa.BigInteger,
+        existing_nullable=False,
+        nullable=True,
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "query_metrics",
+        COLUMN_NAME,
+        schema="raw_metrics",
+        existing_type=sa.BigInteger,
+        existing_nullable=True,
+        nullable=False,
+    )

--- a/alembic/versions/1670737c6856_make_peaktotalnonrevocablememorybytes_.py
+++ b/alembic/versions/1670737c6856_make_peaktotalnonrevocablememorybytes_.py
@@ -1,4 +1,20 @@
-"""make peakTotalNonRevocableMemoryBytes nullable
+"""
+ ** Copyright 2021 Bloomberg Finance L.P.
+ **
+ ** Licensed under the Apache License, Version 2.0 (the "License");
+ ** you may not use this file except in compliance with the License.
+ ** You may obtain a copy of the License at
+ **
+ **     http://www.apache.org/licenses/LICENSE-2.0
+ **
+ ** Unless required by applicable law or agreed to in writing, software
+ ** distributed under the License is distributed on an "AS IS" BASIS,
+ ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ** See the License for the specific language governing permissions and
+ ** limitations under the License.
+
+
+make peakTotalNonRevocableMemoryBytes nullable
 
 Revision ID: 1670737c6856
 Revises: 5951554f7954

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -16,10 +16,11 @@
 
 
 from ._column_metrics import ColumnMetrics
-from ._query_metrics import InitialQueryMetrics, QueryMetrics
+from ._query_metrics import InitialQueryMetrics, QueryMetricsRev2, QueryMetricsRev3
 
 __all__ = (
     "InitialQueryMetrics",
     "ColumnMetrics",
-    "QueryMetrics",
+    "QueryMetricsRev2",
+    "QueryMetricsRev3",
 )

--- a/tests/models/_column_metrics.py
+++ b/tests/models/_column_metrics.py
@@ -18,7 +18,7 @@
 from sqlalchemy import Column, ForeignKey, Integer, String
 from sqlalchemy.orm import declarative_base
 
-from ._query_metrics import QueryMetrics
+from ._query_metrics import QueryMetricsRev2
 
 Base = declarative_base()
 
@@ -26,7 +26,7 @@ Base = declarative_base()
 class ColumnMetrics(Base):
     __tablename__ = "column_metrics"
 
-    queryId = Column("queryId", String(100), ForeignKey(QueryMetrics.queryId), primary_key=True)
+    queryId = Column("queryId", String(100), ForeignKey(QueryMetricsRev2.queryId), primary_key=True)
     catalogName = Column("catalogName", String(100), primary_key=True)
     schemaName = Column("schemaName", String(100), primary_key=True)
     tableName = Column("tableName", String(100), primary_key=True)

--- a/tests/models/_query_metrics.py
+++ b/tests/models/_query_metrics.py
@@ -22,53 +22,7 @@ from sqlalchemy.sql.sqltypes import BigInteger
 Base = declarative_base()
 
 
-class QueryMetrics(Base):
-    __tablename__ = "query_metrics"
-
-    queryId = Column("queryId", String(100), primary_key=True)
-    transactionId = Column("transactionId", String(100))
-    query = Column("query", String(10000))
-    remoteClientAddress = Column("remoteClientAddress", String(100))
-    user = Column("user", String(100))
-    userAgent = Column("userAgent", String(100))
-    source = Column("source", String(100))
-    serverAddress = Column("serverAddress", String(100))
-    serverVersion = Column("serverVersion", String(100))
-    environment = Column("environment", String(10))
-    queryType = Column("queryType", String(50))
-    cpuTime = Column("cpuTime", Float)
-    wallTime = Column("wallTime", Float)
-    queuedTime = Column("queuedTime", Float)
-    scheduledTime = Column("scheduledTime", Float)
-    analysisTime = Column("analysisTime", Float)
-    planningTime = Column("planningTime", Float)
-    executionTime = Column("executionTime", Float)
-    peakUserMemoryBytes = Column("peakUserMemoryBytes", BigInteger)
-    peakTotalNonRevocableMemoryBytes = Column("peakTotalNonRevocableMemoryBytes", BigInteger)
-    peakTaskUserMemory = Column("peakTaskUserMemory", BigInteger)
-    peakTaskTotalMemory = Column("peakTaskTotalMemory", BigInteger)
-    physicalInputBytes = Column("physicalInputBytes", BigInteger)
-    physicalInputRows = Column("physicalInputRows", BigInteger)
-    internalNetworkBytes = Column("internalNetworkBytes", BigInteger)
-    internalNetworkRows = Column("internalNetworkRows", BigInteger)
-    totalBytes = Column("totalBytes", BigInteger)
-    totalRows = Column("totalRows", BigInteger)
-    outputBytes = Column("outputBytes", BigInteger)
-    outputRows = Column("outputRows", BigInteger)
-    writtenBytes = Column("writtenBytes", BigInteger)
-    writtenRows = Column("writtenRows", BigInteger)
-    cumulativeMemory = Column("cumulativeMemory", Float)
-    completedSplits = Column("completedSplits", Integer)
-    resourceWaitingTime = Column("resourceWaitingTime", Float)
-    createTime = Column("createTime", DateTime)
-    executionStartTime = Column("executionStartTime", DateTime)
-    endTime = Column("endTime", DateTime)
-
-    __table_args__ = {"schema": "raw_metrics", "extend_existing": True}
-
-
-class InitialQueryMetrics(Base):
-    __tablename__ = "query_metrics"
+class _InitialQueryMetrics:
 
     queryId = Column("queryId", String(100), primary_key=True)
     transactionId = Column("transactionId", String(100))
@@ -109,4 +63,43 @@ class InitialQueryMetrics(Base):
     executionStartTime = Column("executionStartTime", DateTime)
     endTime = Column("endTime", DateTime)
 
+
+class _QueryMetricsRev2(_InitialQueryMetrics):
+
+    peakUserMemoryBytes = Column("peakUserMemoryBytes", BigInteger)
+    peakTotalNonRevocableMemoryBytes = Column("peakTotalNonRevocableMemoryBytes", BigInteger)
+    peakTaskUserMemory = Column("peakTaskUserMemory", BigInteger)
+    peakTaskTotalMemory = Column("peakTaskTotalMemory", BigInteger)
+    physicalInputBytes = Column("physicalInputBytes", BigInteger)
+    physicalInputRows = Column("physicalInputRows", BigInteger)
+    internalNetworkBytes = Column("internalNetworkBytes", BigInteger)
+    internalNetworkRows = Column("internalNetworkRows", BigInteger)
+    totalBytes = Column("totalBytes", BigInteger)
+    totalRows = Column("totalRows", BigInteger)
+    outputBytes = Column("outputBytes", BigInteger)
+    outputRows = Column("outputRows", BigInteger)
+    writtenBytes = Column("writtenBytes", BigInteger)
+    writtenRows = Column("writtenRows", BigInteger)
+
+
+class _QueryMetricsRev3(_QueryMetricsRev2):
+
+    peakTotalNonRevocableMemoryBytes = Column("peakTotalNonRevocableMemoryBytes", BigInteger, nullable=True)
+
+
+class InitialQueryMetrics(Base, _InitialQueryMetrics):
+    __tablename__ = "query_metrics"
+
     __table_args__ = {"extend_existing": True, "schema": "raw_metrics"}
+
+
+class QueryMetricsRev2(Base, _QueryMetricsRev2):
+    __tablename__ = "query_metrics"
+
+    __table_args__ = {"schema": "raw_metrics", "extend_existing": True}
+
+
+class QueryMetricsRev3(Base, _QueryMetricsRev3):
+    __tablename__ = "query_metrics"
+
+    __table_args__ = {"schema": "raw_metrics", "extend_existing": True}


### PR DESCRIPTION
With Trino version 369 the property `peakTotalNonRevocableMemory` has been removed from `QueryStatistics`.

**Describe your changes**
Makes the database field `peakTotalNonRevocableMemory` nullable.

**Testing performed**
Added a new test for None value and validity of migration.

**Aditional**
Refactored `query_metrics` models to follow a hierarchical structure. (Extending `sqlalchemy.orm.declarative_base()` is the equivalent of creating hierarchical database entities, so we must use intermediate filed-only classes to avoid it)