### PR TITLE
Add more columns and tables for Trino 379

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ __pycache__/
 .pytest_cache
 
 .pre-commit
+
+# virtual environment
+venv
+env

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,11 +7,13 @@ repos:
     hooks:
     -   id: black
         args: ["--safe", "--line-length", "120", "tests", "alembic"]
+        additional_dependencies:
+          - "click==8.0.1"
 -   repo: https://github.com/PyCQA/isort
     rev: 5.9.3
     hooks:
     -   id: isort
-        args: ["--line-length", "120", "tests", "alembic"]
+        args: ["--profile", "black", "--line-length", "120", "tests", "alembic"]
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The purpose of this project is to offer safe migrations for upgrading and downgr
 
 ## Installation
 
-This is meant to be used with [Trino](https://github.com/trinodb/trino) and models data based on Trino's query metrics. This has been tested with [Trino 363](https://github.com/trinodb/trino/releases/tag/363), backwards or forwards compatibility is not guaranteed.
+This is meant to be used with [Trino](https://github.com/trinodb/trino) and models data based on Trino's query metrics. This has been tested with [Trino 379](https://github.com/trinodb/trino/releases/tag/379) and is backwards compatible to [Trino 363](https://github.com/trinodb/trino/releases/tag/363). Compatibility beyond this range is not guaranteed.
 
 Before running this you will need to create a new database `datalake_analytics` with a schema called `datalake_metrics`. This is done by hand and is a one-time configuration.
 

--- a/alembic/versions/d58a144ae68f_379_add_more_tables.py
+++ b/alembic/versions/d58a144ae68f_379_add_more_tables.py
@@ -1,0 +1,119 @@
+"""
+ ** Copyright 2021 Bloomberg Finance L.P.
+ **
+ ** Licensed under the Apache License, Version 2.0 (the "License");
+ ** you may not use this file except in compliance with the License.
+ ** You may obtain a copy of the License at
+ **
+ **     http://www.apache.org/licenses/LICENSE-2.0
+ **
+ ** Unless required by applicable law or agreed to in writing, software
+ ** distributed under the License is distributed on an "AS IS" BASIS,
+ ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ** See the License for the specific language governing permissions and
+ ** limitations under the License.
+
+
+379 add more tables
+
+Revision ID: d58a144ae68f
+Revises: 5951554f7954
+Create Date: 2022-05-05 10:21:10.881234
+
+"""
+from sqlalchemy import JSON, BigInteger, Float, String, UnicodeText
+from sqlalchemy.sql.schema import Column, ForeignKey
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d58a144ae68f"
+down_revision = "1670737c6856"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+
+    for column in [
+        # Statistics columns
+        Column("failedCpuTime", Float, nullable=True),
+        Column("failedScheduledTime", Float, nullable=True),
+        Column("inputBlockedTime", Float, nullable=True),
+        Column("failedInputBlockedTime", Float, nullable=True),
+        Column("outputBlockedTime", Float, nullable=True),
+        Column("failedOutputBlockedTime", Float, nullable=True),
+        Column("processedInputBytes", BigInteger, nullable=True),
+        Column("processedInputRows", BigInteger, nullable=True),
+        Column("planNodeStatsAndCosts", JSON(none_as_null=True), nullable=True),
+        # Metadata
+        Column("uri", String(255), nullable=True),
+        Column("plan", UnicodeText, nullable=True),
+        Column("paylod", JSON(none_as_null=True), nullable=True),
+        # Context
+        Column("sessionProperties", JSON(none_as_null=True), nullable=True),
+    ]:
+        op.add_column("query_metrics", column, schema="raw_metrics")
+
+    op.create_table(
+        "client_tags",
+        Column(
+            "queryId",
+            String(100),
+            ForeignKey("raw_metrics.query_metrics.queryId"),
+            primary_key=True,
+        ),
+        Column("clientTag", String(255), primary_key=True),
+        schema="raw_metrics",
+    )
+
+    op.create_table(
+        "resource_groups",
+        Column(
+            "queryId",
+            String(100),
+            ForeignKey("raw_metrics.query_metrics.queryId"),
+            primary_key=True,
+        ),
+        Column("resourceGroup", String(255), primary_key=True),
+        schema="raw_metrics",
+    )
+
+    op.create_table(
+        "operator_summaries",
+        Column("id", BigInteger, autoincrement=True, primary_key=True),
+        Column(
+            "queryId",
+            String(100),
+            ForeignKey("raw_metrics.query_metrics.queryId"),
+            primary_key=True,
+        ),
+        Column("operatorSummary", JSON(none_as_null=True), nullable=False),
+        schema="raw_metrics",
+    )
+
+
+def downgrade():
+
+    for column in [
+        "failedCpuTime",
+        "failedScheduledTime",
+        "inputBlockedTime",
+        "failedInputBlockedTime",
+        "outputBlockedTime",
+        "failedOutputBlockedTime",
+        "processedInputBytes",
+        "processedInputRows",
+        "uri",
+        "plan",
+        "payload",
+        "planNodeStatsAndCosts",
+        "sessionProperties",
+    ]:
+        op.drop_column("query_metrics", column, schema="raw_metrics")
+
+    op.drop_table("client_tags", schema="raw_metrics")
+
+    op.drop_table("resource_groups", schema="raw_metrics")
+
+    op.drop_table("operator_summaries", schema="raw_metrics")

--- a/tests/models/_client_tags.py
+++ b/tests/models/_client_tags.py
@@ -15,19 +15,23 @@
 """
 
 
-from ._client_tags import ClientTagsInitial
-from ._column_metrics import ColumnMetrics
-from ._operator_summaries import OperatorSummariesInitial
-from ._query_metrics import InitialQueryMetrics, QueryMetricsRev2, QueryMetricsRev3, QueryMetricsRev4
-from ._resource_groups import ResourceGroupsInitial
+from sqlalchemy import Column, ForeignKey, String
+from sqlalchemy.orm import declarative_base
 
-__all__ = (
-    "InitialQueryMetrics",
-    "ColumnMetrics",
-    "QueryMetricsRev2",
-    "QueryMetricsRev3",
-    "QueryMetricsRev4",
-    "ClientTagsInitial",
-    "ResourceGroupsInitial",
-    "OperatorSummariesInitial",
-)
+from ._query_metrics import InitialQueryMetrics
+
+Base = declarative_base()
+
+
+class _ClientTagsInitial:
+
+    clientTag = Column("clientTag", String(255), primary_key=True)
+
+
+class ClientTagsInitial(Base, _ClientTagsInitial):
+
+    __tablename__ = "client_tags"
+
+    queryId = Column("queryId", String(100), ForeignKey(InitialQueryMetrics.queryId), primary_key=True)
+
+    __table_args__ = {"extend_existing": True, "schema": "raw_metrics"}

--- a/tests/models/_operator_summaries.py
+++ b/tests/models/_operator_summaries.py
@@ -1,0 +1,39 @@
+"""
+ ** Copyright 2021 Bloomberg Finance L.P.
+ **
+ ** Licensed under the Apache License, Version 2.0 (the "License");
+ ** you may not use this file except in compliance with the License.
+ ** You may obtain a copy of the License at
+ **
+ **     http://www.apache.org/licenses/LICENSE-2.0
+ **
+ ** Unless required by applicable law or agreed to in writing, software
+ ** distributed under the License is distributed on an "AS IS" BASIS,
+ ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ** See the License for the specific language governing permissions and
+ ** limitations under the License.
+"""
+
+
+from sqlalchemy import JSON, Column, ForeignKey, String
+from sqlalchemy.orm import declarative_base
+from sqlalchemy.sql.sqltypes import BigInteger
+
+from ._query_metrics import InitialQueryMetrics
+
+Base = declarative_base()
+
+
+class _OperatorSummariesInitial:
+
+    id = Column("id", BigInteger, autoincrement=True, primary_key=True)
+    operatorSummary = Column("operatorSummary", JSON(none_as_null=True), nullable=False)
+
+
+class OperatorSummariesInitial(Base, _OperatorSummariesInitial):
+
+    __tablename__ = "operator_summaries"
+
+    queryId = Column("queryId", String(100), ForeignKey(InitialQueryMetrics.queryId), primary_key=True)
+
+    __table_args__ = {"extend_existing": True, "schema": "raw_metrics"}

--- a/tests/models/_query_metrics.py
+++ b/tests/models/_query_metrics.py
@@ -15,7 +15,7 @@
 """
 
 
-from sqlalchemy import Column, DateTime, Float, Integer, String
+from sqlalchemy import JSON, Column, DateTime, Float, Integer, String, UnicodeText
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.sql.sqltypes import BigInteger
 
@@ -87,6 +87,23 @@ class _QueryMetricsRev3(_QueryMetricsRev2):
     peakTotalNonRevocableMemoryBytes = Column("peakTotalNonRevocableMemoryBytes", BigInteger, nullable=True)
 
 
+class _QueryMetricsRev4(_QueryMetricsRev3):
+
+    failedCpuTime = Column("failedCpuTime", Float, nullable=True)
+    failedScheduledTime = Column("failedScheduledTime", Float, nullable=True)
+    inputBlockedTime = Column("inputBlockedTime", Float, nullable=True)
+    failedInputBlockedTime = Column("failedInputBlockedTime", Float, nullable=True)
+    outputBlockedTime = Column("outputBlockedTime", Float, nullable=True)
+    failedOutputBlockedTime = Column("failedOutputBlockedTime", Float, nullable=True)
+    processedInputBytes = Column("processedInputBytes", BigInteger, nullable=True)
+    processedInputRows = Column("processedInputRows", BigInteger, nullable=True)
+    uri = Column("uri", String(255), nullable=True)
+    plan = Column("plan", UnicodeText, nullable=True)
+    payload = Column("paylod", JSON(none_as_null=True), nullable=True)
+    planNodeStatsAndCosts = Column("planNodeStatsAndCosts", JSON(none_as_null=True), nullable=True)
+    sessionProperties = Column("sessionProperties", JSON(none_as_null=True), nullable=True)
+
+
 class InitialQueryMetrics(Base, _InitialQueryMetrics):
     __tablename__ = "query_metrics"
 
@@ -100,6 +117,12 @@ class QueryMetricsRev2(Base, _QueryMetricsRev2):
 
 
 class QueryMetricsRev3(Base, _QueryMetricsRev3):
+    __tablename__ = "query_metrics"
+
+    __table_args__ = {"schema": "raw_metrics", "extend_existing": True}
+
+
+class QueryMetricsRev4(Base, _QueryMetricsRev4):
     __tablename__ = "query_metrics"
 
     __table_args__ = {"schema": "raw_metrics", "extend_existing": True}

--- a/tests/models/_resource_groups.py
+++ b/tests/models/_resource_groups.py
@@ -15,19 +15,23 @@
 """
 
 
-from ._client_tags import ClientTagsInitial
-from ._column_metrics import ColumnMetrics
-from ._operator_summaries import OperatorSummariesInitial
-from ._query_metrics import InitialQueryMetrics, QueryMetricsRev2, QueryMetricsRev3, QueryMetricsRev4
-from ._resource_groups import ResourceGroupsInitial
+from sqlalchemy import Column, ForeignKey, String
+from sqlalchemy.orm import declarative_base
 
-__all__ = (
-    "InitialQueryMetrics",
-    "ColumnMetrics",
-    "QueryMetricsRev2",
-    "QueryMetricsRev3",
-    "QueryMetricsRev4",
-    "ClientTagsInitial",
-    "ResourceGroupsInitial",
-    "OperatorSummariesInitial",
-)
+from ._query_metrics import QueryMetricsRev4
+
+Base = declarative_base()
+
+
+class _ResourceGroupsInitial:
+
+    resourceGroup = Column("resourceGroup", String(255), primary_key=True)
+
+
+class ResourceGroupsInitial(Base, _ResourceGroupsInitial):
+
+    __tablename__ = "resource_groups"
+
+    queryId = Column("queryId", String(100), ForeignKey(QueryMetricsRev4.queryId), primary_key=True)
+
+    __table_args__ = {"extend_existing": True, "schema": "raw_metrics"}


### PR DESCRIPTION
**Describe your changes**
Add `processedInputBytes` and `processedInputRows` columns added in Trino 378/377.
Add `VARCHAR(100) uri`, `TEXT plan`, `JSON payload`, `JSON planNodeStatsAndCosts` and `JSON sessionProperties` columns for storing existing data that wasn't captured before.

Add `client_tag`, `resource_groups`, and `operator_summaries` tables for storing existing data that wasn't captured.

**Testing performed**
Add test for new columns and tables.
