### PR TITLE
Add tables for failed events, output columns and output sources

### DIFF
--- a/alembic/versions/1c7e48e82bed_output_tables.py
+++ b/alembic/versions/1c7e48e82bed_output_tables.py
@@ -1,0 +1,84 @@
+"""
+ ** Copyright 2021 Bloomberg Finance L.P.
+ **
+ ** Licensed under the Apache License, Version 2.0 (the "License");
+ ** you may not use this file except in compliance with the License.
+ ** You may obtain a copy of the License at
+ **
+ **     http://www.apache.org/licenses/LICENSE-2.0
+ **
+ ** Unless required by applicable law or agreed to in writing, software
+ ** distributed under the License is distributed on an "AS IS" BASIS,
+ ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ** See the License for the specific language governing permissions and
+ ** limitations under the License.
+
+
+output tables
+
+Revision ID: 1c7e48e82bed
+Revises: 4602433fb9dc
+Create Date: 2022-05-26 14:05:27.155668
+
+"""
+from sqlalchemy import BigInteger, ForeignKeyConstraint, String
+from sqlalchemy.sql.schema import Column
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1c7e48e82bed"
+down_revision = "4602433fb9dc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "output_columns",
+        Column("queryId", String(100), primary_key=True),
+        Column("catalogName", String(100), primary_key=True),
+        Column("schemaName", String(100), primary_key=True),
+        Column("tableName", String(100), primary_key=True),
+        Column("columnName", String(100), primary_key=True),
+        # Foreign Keys
+        ForeignKeyConstraint(["queryId"], ["raw_metrics.query_metrics.queryId"]),
+        schema="raw_metrics",
+    )
+
+    # Creating a PrimaryKey with all the columns creates a index that is too big
+    # for MySQL (and possibly other databases)
+    # id fields is introduced to reduce to reduce primary key size
+    op.create_table(
+        "output_column_sources",
+        # Output column identifiers
+        Column("id", BigInteger, autoincrement=True, primary_key=True),
+        Column("queryId", String(100), primary_key=True),
+        Column("catalogName", String(100), primary_key=True),
+        Column("schemaName", String(100), primary_key=True),
+        Column("tableName", String(100), primary_key=True),
+        Column("columnName", String(100), primary_key=True),
+        # Source column identifiers
+        Column("sourceCatalogName", String(100)),
+        Column("sourceSchemaName", String(100)),
+        Column("sourceTableName", String(100)),
+        Column("sourceColumnName", String(100)),
+        # Foreign Keys
+        ForeignKeyConstraint(
+            ["queryId", "catalogName", "schemaName", "tableName", "columnName"],
+            [
+                "raw_metrics.output_columns.queryId",
+                "raw_metrics.output_columns.catalogName",
+                "raw_metrics.output_columns.schemaName",
+                "raw_metrics.output_columns.tableName",
+                "raw_metrics.output_columns.columnName",
+            ],
+        ),
+        schema="raw_metrics",
+    )
+
+
+def downgrade():
+    op.drop_table("output_column_sources", schema="raw_metrics")
+
+    op.drop_table("output_columns", schema="raw_metrics")

--- a/alembic/versions/4602433fb9dc_add_failed_table.py
+++ b/alembic/versions/4602433fb9dc_add_failed_table.py
@@ -1,0 +1,47 @@
+"""
+ ** Copyright 2021 Bloomberg Finance L.P.
+ **
+ ** Licensed under the Apache License, Version 2.0 (the "License");
+ ** you may not use this file except in compliance with the License.
+ ** You may obtain a copy of the License at
+ **
+ **     http://www.apache.org/licenses/LICENSE-2.0
+ **
+ ** Unless required by applicable law or agreed to in writing, software
+ ** distributed under the License is distributed on an "AS IS" BASIS,
+ ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ** See the License for the specific language governing permissions and
+ ** limitations under the License.
+
+
+add failed table
+
+Revision ID: 4602433fb9dc
+Revises: d58a144ae68f
+Create Date: 2022-05-25 12:38:56.355558
+
+"""
+from sqlalchemy import BigInteger, DateTime, UnicodeText, func
+from sqlalchemy.sql.schema import Column
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4602433fb9dc"
+down_revision = "d58a144ae68f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "failed_events",
+        Column("id", BigInteger, primary_key=True, autoincrement=True),
+        Column("event", UnicodeText, nullable=False),
+        Column("createTime", DateTime, nullable=False, server_default=func.now()),
+        schema="raw_metrics",
+    )
+
+
+def downgrade():
+    op.drop_table("failed_events", schema="raw_metrics")

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -19,6 +19,8 @@ from ._client_tags import ClientTagsInitial
 from ._column_metrics import ColumnMetrics
 from ._failed_events import FailedEventInitial
 from ._operator_summaries import OperatorSummariesInitial
+from ._output_column import OutputColumn
+from ._output_column_source import OutputColumnSource
 from ._query_metrics import InitialQueryMetrics, QueryMetricsRev2, QueryMetricsRev3, QueryMetricsRev4
 from ._resource_groups import ResourceGroupsInitial
 
@@ -32,4 +34,6 @@ __all__ = (
     "ResourceGroupsInitial",
     "OperatorSummariesInitial",
     "FailedEventInitial",
+    "OutputColumn",
+    "OutputColumnSource",
 )

--- a/tests/models/_failed_events.py
+++ b/tests/models/_failed_events.py
@@ -15,21 +15,21 @@
 """
 
 
-from ._client_tags import ClientTagsInitial
-from ._column_metrics import ColumnMetrics
-from ._failed_events import FailedEventInitial
-from ._operator_summaries import OperatorSummariesInitial
-from ._query_metrics import InitialQueryMetrics, QueryMetricsRev2, QueryMetricsRev3, QueryMetricsRev4
-from ._resource_groups import ResourceGroupsInitial
+from sqlalchemy import BigInteger, Column, DateTime, UnicodeText, func
+from sqlalchemy.orm import declarative_base
 
-__all__ = (
-    "InitialQueryMetrics",
-    "ColumnMetrics",
-    "QueryMetricsRev2",
-    "QueryMetricsRev3",
-    "QueryMetricsRev4",
-    "ClientTagsInitial",
-    "ResourceGroupsInitial",
-    "OperatorSummariesInitial",
-    "FailedEventInitial",
-)
+Base = declarative_base()
+
+
+class _FailedEventInitial:
+
+    id = Column("id", BigInteger, autoincrement=True, primary_key=True)
+    event = Column("event", UnicodeText, nullable=False)
+    createTime = Column("createTime", DateTime, nullable=False, default=func.now())
+
+
+class FailedEventInitial(_FailedEventInitial, Base):
+
+    __tablename__ = "failed_events"
+
+    __table_args__ = {"extend_existing": True, "schema": "raw_metrics"}

--- a/tests/models/_output_column.py
+++ b/tests/models/_output_column.py
@@ -1,0 +1,42 @@
+"""
+ ** Copyright 2021 Bloomberg Finance L.P.
+ **
+ ** Licensed under the Apache License, Version 2.0 (the "License");
+ ** you may not use this file except in compliance with the License.
+ ** You may obtain a copy of the License at
+ **
+ **     http://www.apache.org/licenses/LICENSE-2.0
+ **
+ ** Unless required by applicable law or agreed to in writing, software
+ ** distributed under the License is distributed on an "AS IS" BASIS,
+ ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ** See the License for the specific language governing permissions and
+ ** limitations under the License.
+"""
+
+
+from sqlalchemy import Column, ForeignKeyConstraint, String
+from sqlalchemy.orm import declarative_base
+
+from ._query_metrics import QueryMetricsRev4
+
+Base = declarative_base()
+
+
+class _OutputColumnInitial:
+
+    queryId = Column("queryId", String(100), primary_key=True)
+    catalogName = Column("catalogName", String(100), primary_key=True)
+    schemaName = Column("schemaName", String(100), primary_key=True)
+    tableName = Column("tableName", String(100), primary_key=True)
+    columnName = Column("columnName", String(100), primary_key=True)
+
+
+class OutputColumn(_OutputColumnInitial, Base):
+
+    __tablename__ = "output_columns"
+
+    __table_args__ = (
+        ForeignKeyConstraint([_OutputColumnInitial.queryId], [QueryMetricsRev4.queryId]),
+        {"extend_existing": True, "schema": "raw_metrics"},
+    )

--- a/tests/models/_output_column_source.py
+++ b/tests/models/_output_column_source.py
@@ -1,0 +1,62 @@
+"""
+ ** Copyright 2021 Bloomberg Finance L.P.
+ **
+ ** Licensed under the Apache License, Version 2.0 (the "License");
+ ** you may not use this file except in compliance with the License.
+ ** You may obtain a copy of the License at
+ **
+ **     http://www.apache.org/licenses/LICENSE-2.0
+ **
+ ** Unless required by applicable law or agreed to in writing, software
+ ** distributed under the License is distributed on an "AS IS" BASIS,
+ ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ** See the License for the specific language governing permissions and
+ ** limitations under the License.
+"""
+
+
+from sqlalchemy import BigInteger, Column, ForeignKeyConstraint, String
+from sqlalchemy.orm import declarative_base
+
+from ._output_column import OutputColumn
+
+Base = declarative_base()
+
+
+class _OutputColumnSourceInitial:
+
+    id = Column("id", BigInteger, autoincrement=True, primary_key=True)
+    queryId = Column("queryId", String(100), primary_key=True)
+    catalogName = Column("catalogName", String(100), primary_key=True)
+    schemaName = Column("schemaName", String(100), primary_key=True)
+    tableName = Column("tableName", String(100), primary_key=True)
+    columnName = Column("columnName", String(100), primary_key=True)
+    sourceCatalogName = Column("sourceCatalogName", String(100))
+    sourceSchemaName = Column("sourceSchemaName", String(100))
+    sourceTableName = Column("sourceTableName", String(100))
+    sourceColumnName = Column("sourceColumnName", String(100))
+
+
+class OutputColumnSource(_OutputColumnSourceInitial, Base):
+
+    __tablename__ = "output_column_sources"
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            [
+                _OutputColumnSourceInitial.queryId,
+                _OutputColumnSourceInitial.catalogName,
+                _OutputColumnSourceInitial.schemaName,
+                _OutputColumnSourceInitial.tableName,
+                _OutputColumnSourceInitial.columnName,
+            ],
+            [
+                OutputColumn.queryId,
+                OutputColumn.catalogName,
+                OutputColumn.schemaName,
+                OutputColumn.tableName,
+                OutputColumn.columnName,
+            ],
+        ),
+        {"extend_existing": True, "schema": "raw_metrics"},
+    )


### PR DESCRIPTION
**Describe your changes**
Add a table for failed events, so that events cannot be processed successfully by [datalake-query-db-consumer](https://github.com/bloomberg/datalake-query-db-consumer) are not lost.

Add a table for output columns and a table for output column sources.

**Testing performed**
Add tests for new tables