### PR TITLE
Change `query` column to `TEXT`, create `query_metrics` indecies

### DIFF
--- a/alembic/versions/32174e9fc8be_add_query_metrics_indecies.py
+++ b/alembic/versions/32174e9fc8be_add_query_metrics_indecies.py
@@ -1,0 +1,46 @@
+"""
+ ** Copyright 2021 Bloomberg Finance L.P.
+ **
+ ** Licensed under the Apache License, Version 2.0 (the "License");
+ ** you may not use this file except in compliance with the License.
+ ** You may obtain a copy of the License at
+ **
+ **     http://www.apache.org/licenses/LICENSE-2.0
+ **
+ ** Unless required by applicable law or agreed to in writing, software
+ ** distributed under the License is distributed on an "AS IS" BASIS,
+ ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ** See the License for the specific language governing permissions and
+ ** limitations under the License.
+
+
+add query_metrics indecies
+
+Revision ID: 32174e9fc8be
+Revises: d3cb6e144c2c
+Create Date: 2022-08-23 11:19:38.183700
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "32174e9fc8be"
+down_revision = "d3cb6e144c2c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "createtime_index", "query_metrics", ["createTime"], schema="raw_metrics", postgresql_concurrently=True
+        )
+
+        op.create_index("user_index", "query_metrics", ["user"], schema="raw_metrics", postgresql_concurrently=True)
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.drop_index("createtime_index", "query_metrics", schema="raw_metrics", postgresql_concurrently=True)
+
+        op.drop_column("user_index", "query_metrics", schema="raw_metrics", postgresql_concurrently=True)

--- a/alembic/versions/d3cb6e144c2c_increase_query_size.py
+++ b/alembic/versions/d3cb6e144c2c_increase_query_size.py
@@ -1,0 +1,44 @@
+"""
+ ** Copyright 2021 Bloomberg Finance L.P.
+ **
+ ** Licensed under the Apache License, Version 2.0 (the "License");
+ ** you may not use this file except in compliance with the License.
+ ** You may obtain a copy of the License at
+ **
+ **     http://www.apache.org/licenses/LICENSE-2.0
+ **
+ ** Unless required by applicable law or agreed to in writing, software
+ ** distributed under the License is distributed on an "AS IS" BASIS,
+ ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ** See the License for the specific language governing permissions and
+ ** limitations under the License.
+
+
+increase query size
+
+Revision ID: d3cb6e144c2c
+Revises: 1c7e48e82bed
+Create Date: 2022-08-23 10:00:40.375381
+
+"""
+from sqlalchemy import String, Text
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d3cb6e144c2c"
+down_revision = "1c7e48e82bed"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "query_metrics", "query", existing_type=String(10_000), existing_nullable=True, type_=Text, schema="raw_metrics"
+    )
+
+
+def downgrade():
+    op.alter_column(
+        "query_metrics", "query", existing_type=Text, existing_nullable=True, type_=String(10_000), schema="raw_metrics"
+    )


### PR DESCRIPTION
**Describe your changes**
Increase the size of the `query` column in `query_metrics`, making it unbounded.

Add 2 more indices on `query_metrics` to increase the query filtering speed on `createtime` and `user`.

**Testing performed**
Added tests to ensure `query` supports larger texts and Unicode characters and current data is not modified.
